### PR TITLE
Fix mobile controls double-tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
       font-size: 20px;
       background-color: #fff;
       border: none;
+      touch-action: manipulation;
     }
     #btn-up { grid-area: up; }
     #btn-down { grid-area: down; }


### PR DESCRIPTION
## Summary
- disable double-tap zoom for the on-screen controls by setting `touch-action: manipulation`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6844d482210c832b98ebfab44308f598