### PR TITLE
Show Froggy game over sprite on defeat

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,6 +235,7 @@
       endMessage.textContent = 'Game Over!';
       endMessage.style.color = 'red';
       endMessage.style.display = 'block';
+      froggy.style.backgroundImage = "url('froggy-gameover.png')";
       gameActive = false;
   }
 


### PR DESCRIPTION
## Summary
- display `froggy-gameover.png` when the player loses

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844df4fc270832b904866025576a778