### PR TITLE
Add win sprite and layer adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,7 @@
       endMessage.style.color = 'red';
       endMessage.style.display = 'block';
       froggy.style.backgroundImage = "url('froggy-gameover.png')";
+      froggy.style.zIndex = '2';
       gameActive = false;
   }
 
@@ -283,6 +284,8 @@ function performAttack() {
       endMessage.textContent = 'You win!';
       endMessage.style.color = 'blue';
       endMessage.style.display = 'block';
+      froggy.style.backgroundImage = "url('froggy-win.png')";
+      froggy.style.zIndex = '2';
       gameActive = false;
       stopCountdown();
     }
@@ -344,6 +347,7 @@ function performAttack() {
     updatePosition();
     whale.style.backgroundImage = "url('whale-boss.png')";
     updateWhalePosition();
+    froggy.style.zIndex = '';
     stopCountdown();
   }
 


### PR DESCRIPTION
## Summary
- show Froggy win sprite when defeating the whale
- ensure Froggy appears above the whale when the game ends
- reset layering when starting a new game

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844e72ab3ec832bb6d163cfb7591e3c