### PR TITLE
Fix froggy win sprite clearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,9 @@ function performAttack() {
   if (!gameActive) return;
   froggy.style.backgroundImage = `url('${attackSprites[currentDirection]}')`;
   setTimeout(() => {
-    froggy.style.backgroundImage = `url('${directions[currentDirection]}')`;
+    if (gameActive) {
+      froggy.style.backgroundImage = `url('${directions[currentDirection]}')`;
+    }
   }, 300);
   const dx = x - whaleX;
   const dy = y - whaleY;


### PR DESCRIPTION
## Summary
- stop attack animation from overwriting the win image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844ec0c3f68832b8a5ceaea5a630f8c