### PR TITLE
Add minion health bars and mini whale combat

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,30 @@
       height: 75px;
       background-size: cover;
     }
+    .minion-health-container {
+      position: absolute;
+      top: -10px;
+      left: 0;
+      display: flex;
+      align-items: center;
+      width: 100%;
+    }
+    .minion-health-bar {
+      width: 100%;
+      height: 5px;
+      background-color: red;
+    }
+    .minion-health {
+      height: 100%;
+      background-color: green;
+      width: 100%;
+    }
+    .minion-hp {
+      margin-right: 2px;
+      color: white;
+      font-weight: bold;
+      font-size: 10px;
+    }
   </style>
 </head>
 <body>
@@ -172,7 +196,12 @@
           <div id="froggy-health-bar"><div id="froggy-health"></div></div>
         </div>
       </div>
-      <div id="bearbear"></div>
+      <div id="bearbear">
+        <div class="minion-health-container">
+          <span id="bear-hp" class="minion-hp"></span>
+          <div class="minion-health-bar"><div id="bear-health" class="minion-health"></div></div>
+        </div>
+      </div>
       <div id="whale">
         <div id="whale-health-container">
           <span id="whale-hp"></span>
@@ -207,6 +236,8 @@
     const whaleHpText = document.getElementById('whale-hp');
     const froggyHealthFill = document.getElementById('froggy-health');
     const froggyHpText = document.getElementById('froggy-hp');
+    const bearHealthFill = document.getElementById('bear-health');
+    const bearHpText = document.getElementById('bear-hp');
     const endMessage = document.getElementById('end-message');
     const actionLog = document.getElementById('action-log');
     let x = 50;
@@ -220,6 +251,9 @@
     let whaleHealth = maxWhaleHealth;
     const maxFroggyHealth = 10;
     let froggyHealth = maxFroggyHealth;
+    const maxBearHealth = 1;
+    let bearHealth = maxBearHealth;
+    const maxMiniWhaleHealth = 1;
     let countdownInterval = null;
     let gameActive = true;
 
@@ -271,6 +305,18 @@
       const percent = (froggyHealth / maxFroggyHealth) * 100;
       froggyHealthFill.style.width = percent + '%';
       froggyHpText.textContent = froggyHealth;
+  }
+
+  function updateBearHealthBar() {
+      const percent = (bearHealth / maxBearHealth) * 100;
+      bearHealthFill.style.width = percent + '%';
+      bearHpText.textContent = bearHealth;
+  }
+
+  function updateMiniWhaleHealthBar(mw) {
+      const percent = (mw.health / maxMiniWhaleHealth) * 100;
+      mw.healthFill.style.width = percent + '%';
+      mw.hpText.textContent = mw.health;
   }
 
   function logAttack(attacker, victim, damage, died) {
@@ -328,6 +374,8 @@
       updateWhalePosition();
       if (bearAlive && Math.hypot(bearX - whaleX, bearY - whaleY) <= 100) {
           bearAlive = false;
+          bearHealth = 0;
+          updateBearHealthBar();
           bearbear.style.display = 'none';
       }
   }
@@ -420,6 +468,21 @@ function performAttack() {
       stopCountdown();
     }
   }
+
+  for (let i = miniWhales.length - 1; i >= 0; i--) {
+    const mw = miniWhales[i];
+    const mdx = x - mw.x;
+    const mdy = y - mw.y;
+    if (Math.hypot(mdx, mdy) <= 100) {
+      mw.health--;
+      logAttack('Froggy', 'Mini Whale', 1, mw.health <= 0);
+      updateMiniWhaleHealthBar(mw);
+      if (mw.health <= 0) {
+        mw.el.remove();
+        miniWhales.splice(i, 1);
+      }
+    }
+  }
 }
 
 function moveMiniWhales() {
@@ -452,6 +515,8 @@ function moveMiniWhales() {
         // collision with bearbear
         if (bearAlive && Math.hypot(bearX - mw.x, bearY - mw.y) <= 50) {
             bearAlive = false;
+            bearHealth = 0;
+            updateBearHealthBar();
             bearbear.style.display = 'none';
             mw.el.remove();
             miniWhales.splice(i,1);
@@ -466,8 +531,21 @@ function spawnMiniWhale() {
     el.style.backgroundImage = "url('minion-whale.png')";
     el.style.left = Math.random()*600 + 'px';
     el.style.top = Math.random()*300 + 'px';
-    const obj = {el, x: parseFloat(el.style.left), y: parseFloat(el.style.top), lastAttack: 0};
+    const hpContainer = document.createElement('div');
+    hpContainer.className = 'minion-health-container';
+    hpContainer.innerHTML = '<span class="minion-hp"></span><div class="minion-health-bar"><div class="minion-health"></div></div>';
+    el.appendChild(hpContainer);
+    const obj = {
+      el,
+      x: parseFloat(el.style.left),
+      y: parseFloat(el.style.top),
+      lastAttack: 0,
+      health: maxMiniWhaleHealth,
+      hpText: hpContainer.querySelector('.minion-hp'),
+      healthFill: hpContainer.querySelector('.minion-health')
+    };
     document.getElementById('game-container').appendChild(el);
+    updateMiniWhaleHealthBar(obj);
     miniWhales.push(obj);
 }
 
@@ -550,8 +628,10 @@ function bearAttack() {
     whaleY = 200;
     whaleHealth = maxWhaleHealth;
     froggyHealth = maxFroggyHealth;
+    bearHealth = maxBearHealth;
     updateWhaleHealthBar();
     updateFroggyHealthBar();
+    updateBearHealthBar();
     gameActive = true;
     banner.textContent = instructions;
     endMessage.style.display = 'none';


### PR DESCRIPTION
## Summary
- enable Froggy attacks on mini whales
- display health bars with HP numbers over Bearbear and mini whales

## Testing
- `node -e "const fs=require('fs');const s=fs.readFileSync('index.html','utf8').match(/<script>([\s\S]*)<\/script>/)[1];new Function(s);console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684a2fd3e838832bb9134b67d48db97d